### PR TITLE
deco: split decoration and surface, improve performances when decoration is hidden

### DIFF
--- a/src/deco/meson.build
+++ b/src/deco/meson.build
@@ -14,5 +14,5 @@ swayfire_deco = shared_module('swayfire-deco', plugin_src,
     dependencies: [wayfire, wlroots, pixman],
     link_with: swayfire_core,
     install_rpath: get_option('prefix') / get_option('libdir') / 'wayfire',
-    install: true, 
+    install: true,
     install_dir: get_option('libdir') / 'wayfire')


### PR DESCRIPTION
Split the Surface from the Decoration to make it compatible with the wayfire 0.8 API.
Remove the surface of a window if its decoration is meant to be hidden (either toggled manually or when in fullscreen). It should improve performances by allowing Wayfire to perform a scan out when possible (on fullscreen windows, for example).