### PR TITLE
Unbreak build on non-glibc systems

### DIFF
--- a/src/core/core.hpp
+++ b/src/core/core.hpp
@@ -1,9 +1,8 @@
 #ifndef SWAYFIRE_CORE_HPP
 #define SWAYFIRE_CORE_HPP
 
-#include <bits/stdint-intn.h>
-#include <bits/stdint-uintn.h>
 #include <cassert>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <sys/types.h>

--- a/src/pch/prefix.hpp
+++ b/src/pch/prefix.hpp
@@ -7,8 +7,7 @@
 #include <utility>
 #include <vector>
 
-#include <bits/stdint-intn.h>
-#include <bits/stdint-uintn.h>
+#include <cstdint>
 #include <sys/types.h>
 
 #include <wayfire/config/types.hpp>


### PR DESCRIPTION
Found on FreeBSD but Alpine Linux (musl) maybe affected as well.
```c++
$ meson setup /tmp/swayfire_build && meson compile -C /tmp/swayfire_build
src/pch/prefix.hpp:10:10: fatal error: 'bits/stdint-intn.h' file not found
#include <bits/stdint-intn.h>
         ^~~~~~~~~~~~~~~~~~~~
$ meson setup -Db_pch=false /tmp/swayfire_build && meson compile -C /tmp/swayfire_build
src/core/core.hpp:4:10: fatal error: 'bits/stdint-intn.h' file not found
#include <bits/stdint-intn.h>
         ^~~~~~~~~~~~~~~~~~~~
```
