### PR TITLE
build: don't use wayfire's pkgconfig metadata_dir var

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,7 @@ add_project_arguments(['-DWAYFIRE_PLUGIN'], language: ['cpp', 'c'])
 add_project_link_arguments(['-rdynamic'], language:'cpp')
 
 resource_dir = join_paths(get_option('prefix'), 'share', 'wayfire')
-metadata_dir = join_paths(resource_dir, 'metadata', 'swayfire')
+metadata_dir = join_paths(resource_dir, 'metadata')
 
 all_src = []
 

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,9 @@ add_project_arguments(['-DWLR_USE_UNSTABLE'], language: ['cpp', 'c'])
 add_project_arguments(['-DWAYFIRE_PLUGIN'], language: ['cpp', 'c'])
 add_project_link_arguments(['-rdynamic'], language:'cpp')
 
+resource_dir = join_paths(get_option('prefix'), 'share', 'wayfire')
+metadata_dir = join_paths(resource_dir, 'metadata', 'swayfire')
+
 all_src = []
 
 subdir('src')

--- a/metadata/meson.build
+++ b/metadata/meson.build
@@ -1,2 +1,2 @@
-install_data('swayfire.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
-install_data('swayfire-deco.xml', install_dir: wayfire.get_variable(pkgconfig: 'metadatadir'))
+install_data('swayfire.xml', install_dir: metadata_dir)
+install_data('swayfire-deco.xml', install_dir: metadata_dir)


### PR DESCRIPTION
Hi! Before commenting about this PR, thank you for this nice plugin.

I've been trying NixOS with Wayfire and wanted to install a plugin outside of the default ones. The problem occurrs during the installation of the .xml metadata files because Nix won't let me doing it on the Wayfire's prefix. This [PR](https://github.com/WayfireWM/wayfire/issues/493) has a more complete explanation and a half part of my solution.

Looking around other external plugins, I've found [this commit](https://github.com/WayfireWM/wf-shell/commit/482f00455f0b0e08e3fffc844c865e43c80df84b) by the same author of the mentioned PR and it clicked with me. So, I forked this repo, commited almost the same changes, set the `WAYFIRE_PLUGIN_*` env variables, and currently it works very well!

I've never used meson before, but I hope it's the solution I'm looking for.