### PR TITLE
Adjust meson.build dependency versions for correct packages

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,9 +13,9 @@ project(
 	],
 )
 
-wayfire = dependency('wayfire', version: '>=0.8.0')
+wayfire = dependency('wayfire')
 wlroots = dependency('wlroots')
-wfconfig = dependency('wf-config')
+wfconfig = dependency('wf-config', version: '>=0.8.0')
 cairo = dependency('cairo')
 pixman = dependency('pixman-1')
 


### PR DESCRIPTION
This is related to #50 

The dependencies for Wayfire seem incorrectly set. Attempting to build via either the AUR or source results in dependency errors. Looking at the base repository for Wayfire the `>=0.8.0` version is set for `wf-config`.

Adjusting the dependencies according to these changes makes the package buildable and installable again.